### PR TITLE
Updates box api

### DIFF
--- a/jsonconfig/jsonutils.py
+++ b/jsonconfig/jsonutils.py
@@ -26,4 +26,4 @@ def from_json(data, **from_json_kwargs):
         raise JsonDecodeError(e)
 
 
-to_json = box._to_json
+to_json = box.box._to_json


### PR DESCRIPTION
`box._to_json` appears to be `box.box._to_json` in the current version of `box`.  See issue #218